### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/cruft.yml
+++ b/.github/workflows/cruft.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Create pull request
         if: steps.check.outputs.has_changes == '1'
         run: |
-          echo "::set-output name=branch::${{ matrix.branch }}"
-          echo "::set-output name=commit-message::${{ matrix.commit-message }}"
+          echo "branch=${{ matrix.branch }}" >> "$GITHUB_OUTPUT"
+          echo "commit-message=${{ matrix.commit-message }}" >> "$GITHUB_OUTPUT"
           git checkout -b "${{ matrix.branch }}"
           git add ${{ matrix.add-paths }}
           git commit -m "${{ matrix.commit-message }}"


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter